### PR TITLE
Disable peak finding due to bug, replace colon with dash for windows …

### DIFF
--- a/lab_toolbox/lab_toolbox.py
+++ b/lab_toolbox/lab_toolbox.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-'''
+"""
 This file contains the functions that support data transformations
 during the processes in the SOIL lab.
-'''
+"""
 import numpy as np
 import pandas as pd
 from lab_toolbox.constants import constants
@@ -18,15 +18,15 @@ import datetime
 
 
 class Measurement:
-    ''' A class to hold a single measurement and its associated data  '''
-    def __init__(self, name, raw_data):
+    """A class to hold a single measurement and its associated data"""
 
+    def __init__(self, name, raw_data):
         self.name = name
         self.raw_data = raw_data
 
         self._baseline_selected_points = [self.x[0], self.x[-1]]
         self._spline = np.array([])
-        self.update_spline(interpolation_method='linear')
+        self.update_spline(interpolation_method="linear")
 
         self._integral_selected_points = []
         self._integration_properties = []
@@ -43,12 +43,12 @@ class Measurement:
         self._baseline_selected_points.remove(x_coord)
 
     def add_integral_point(self, x_coord):
-        ''' Adds a point to a list which are used to calculate an integral '''
+        """Adds a point to a list which are used to calculate an integral"""
 
         self._integral_selected_points.append(x_coord)
 
     def remove_integral_point(self, x_coord):
-        ''' Remove a point from the list of points used to gen. an integral '''
+        """Remove a point from the list of points used to gen. an integral"""
 
         if x_coord not in self._integral_selected_points:
             raise ValueError(
@@ -87,22 +87,25 @@ class Measurement:
             # which is a subset of self.x, create an array of the
             # associated y value in self.y and update the spline with those
             # points
-            pairs = np.array([
-                (x, self.y[np.where(self.x == x)][0])
-                for x in self.baseline_selected_points
-            ])
+            pairs = np.array(
+                [
+                    (x, self.y[np.where(self.x == x)][0])
+                    for x in self.baseline_selected_points
+                ]
+            )
 
             if len(self.baseline_selected_points) < 4:
                 # If less than two points have been chosen, fit with polyline
                 self._spline = fitter.interp_pts(
                     self.x.reshape(-1, 1),
                     baseline_points=pairs,
-                    interp_method='linear')[0]
+                    interp_method="linear",
+                )[0]
             else:
                 self._spline = fitter.interp_pts(
                     self.x.reshape(-1, 1),
                     baseline_points=pairs,
-                    interp_method=interpolation_method
+                    interp_method=interpolation_method,
                 )[0]
 
         except ValueError as e:
@@ -113,28 +116,31 @@ class Measurement:
         try:
             return self.y - self.spline
         except TypeError:
-            print(f"Spline error on {self.name} with last calculation, "
-                  "returning raw data")
+            print(
+                f"Spline error on {self.name} with last calculation, "
+                "returning raw data"
+            )
             return self.y
 
     @property
     def integral_peaks(self):
-        ''' Returns a list of x values for the peaks '''
+        """Returns a list of x values for the peaks"""
         peaks = []
+
         for prop in self._integration_properties:
-            if prop['peak_x'] is not None and not np.isnan(prop['peak_x']):
-                peaks.append(prop['peak_x'])
+            if prop["peak_x"] is not None and not np.isnan(prop["peak_x"]):
+                peaks.append(prop["peak_x"])
 
         return peaks
 
     def save_plot(self, output_dir):
-        ''' Outputs a plot of the measurement to the specified path '''
+        """Outputs a plot of the measurement to the specified path"""
 
         fig = go.Figure(
             go.Scatter(
-                x=self.x/60,
-                y=self.filtered_baseline*10**6,
-                mode='lines',
+                x=self.x / 60,
+                y=self.filtered_baseline * 10**6,
+                mode="lines",
                 name=self.name,
             )
         )
@@ -144,10 +150,8 @@ class Measurement:
             xaxis_title="Time (min)",
             yaxis_title="Current (μA)",
             font=dict(
-                family="Courier New, monospace",
-                size=18,
-                color="RebeccaPurple"
-            )
+                family="Courier New, monospace", size=18, color="RebeccaPurple"
+            ),
         )
         # Remove the / from the filename if exists
         filename = os.path.join(output_dir, f"{self.name.split('/')[0]}.png")
@@ -155,14 +159,13 @@ class Measurement:
         fig.write_image(filename, width=1980, height=1080)
         print(f"Saved plot to {filename}")
 
-    def find_peak(
-            self,
-            x_start,
-            x_end
-    ) -> Tuple[float, float | int]:
-        ''' Finds the peak value between the x_start and x_end values
+    def find_peak(self, x_start, x_end) -> Tuple[float, float | int]:
+        """Finds the peak value between the x_start and x_end values
 
         Uses the filtered baseline data to find the peak.
+
+        Disable for now until we can make peaks more robust. This was causing
+        problems on selecting data where peaks were not present.
 
         Parameters
         ----------
@@ -176,17 +179,15 @@ class Measurement:
         Tuple[float | int, float]
             The x and y values of the peak, the data type of the x value
             depends on the data type of the x values in the measurement
-        '''
-
+        """
+        return None, None
         # Get the filtered baseline data between the start and end points
         y = self.filtered_baseline[
             np.where((self.x >= x_start) & (self.x <= x_end))
         ]
 
         # Get the x values between the start and end points
-        x = self.x[
-            np.where((self.x >= x_start) & (self.x <= x_end))
-        ]
+        x = self.x[np.where((self.x >= x_start) & (self.x <= x_end))]
 
         # Find the peak absolute value from the filtered baseline
         peak_y = np.max(np.abs(y))
@@ -199,9 +200,9 @@ class Measurement:
     def _calculate_integrals(
         self,
         samples,
-        integration_method: str = 'simpson',
+        integration_method: str = "simpson",
     ) -> List[Dict[str, int | float]]:
-        ''' Calculates the area under the curve between the selected points
+        """Calculates the area under the curve between the selected points
 
         Uses the filtered baseline for data and the selected points to
         calculate the area under the curve between the points.
@@ -224,11 +225,11 @@ class Measurement:
         List[Tuple[float, float, float]]
             A list of tuples containing the start and end points of the
             integral and the area under the curve between those points
-        '''
+        """
 
         # Get list of tuples of start and end points
         ranges_all = [
-            self.integral_selected_points[x:x+2]
+            self.integral_selected_points[x : x + 2]
             for x in range(0, len(self.integral_selected_points), 2)
         ]
         # Remove any ranges that are not complete (groups of 2)
@@ -242,9 +243,7 @@ class Measurement:
             ]
 
             # Get X values between start and end
-            x_values = self.x[
-                np.where((self.x >= start) & (self.x <= end))
-            ]
+            x_values = self.x[np.where((self.x >= start) & (self.x <= end))]
 
             # Calculate the integral
             area = integrate_coulomb_as_mole(
@@ -253,33 +252,35 @@ class Measurement:
 
             peak_x, peak_y = self.find_peak(start, end)
 
-            self._integration_properties.append({
-                "start": start,
-                "end": end,
-                "area": area,
-                "peak_x": peak_x,
-                "peak_y": peak_y
-            })
+            self._integration_properties.append(
+                {
+                    "start": start,
+                    "end": end,
+                    "area": area,
+                    "peak_x": peak_x,
+                    "peak_y": peak_y,
+                }
+            )
 
         # Buffer output list with NaNs to match the number of samples
         while len(self._integration_properties) < samples:
-            self._integration_properties.append({
-                "start": np.nan,
-                "end": np.nan,
-                "area": np.nan,
-                "peak_x": np.nan,
-                "peak_y": np.nan
-            })
+            self._integration_properties.append(
+                {
+                    "start": np.nan,
+                    "end": np.nan,
+                    "area": np.nan,
+                    "peak_x": np.nan,
+                    "peak_y": np.nan,
+                }
+            )
 
         return self._integration_properties
 
 
 def integrate_coulomb_as_mole(
-    y: np.ndarray,
-    x: np.ndarray,
-    method: str = 'trapz'
+    y: np.ndarray, x: np.ndarray, method: str = "trapz"
 ) -> float:
-    ''' Calculate the integral of the x and y values and convert to moles
+    """Calculate the integral of the x and y values and convert to moles
 
     The Faraday constant is used to convert the integral to moles.
 
@@ -297,11 +298,11 @@ def integrate_coulomb_as_mole(
     -------
     float
         The integral of the x and y values converted to moles
-    '''
+    """
 
-    if method == 'trapz':
+    if method == "trapz":
         area = np.trapz(y, x)
-    elif method == 'simpson':
+    elif method == "simpson":
         area = simpson(y, x)
     else:
         raise ValueError(
@@ -317,12 +318,12 @@ def integrate_coulomb_as_mole(
 
 def filter_baseline_interactively(
     measurements: Dict[str, Measurement],
-    interpolation_method: str = 'linear',
+    interpolation_method: str = "linear",
 ) -> go.Figure:
-    ''' Generates a subplot given the dictionary of measurements
+    """Generates a subplot given the dictionary of measurements
 
     Allows user interaction to define the baseline points
-    '''
+    """
 
     def cb_update_baseline_filter_plot(trace, points, selector):
         # Must iterate through each plot in the subplot as everytime on_click
@@ -333,7 +334,6 @@ def filter_baseline_interactively(
                 and len(points.point_inds)
                 and "filtered" not in points.trace_name
             ):  # Make sure we're working on the plot with changes
-
                 point_color = list(subplot.marker.color)
                 point_size = list(subplot.marker.size)
                 measurement = measurements[points.trace_name]
@@ -354,8 +354,7 @@ def filter_baseline_interactively(
                     # color and size. If not in list, return them to default
                     # Get the mask of the selected points against the x array
                     mask = np.isin(
-                        measurement.x,
-                        measurement.baseline_selected_points
+                        measurement.x, measurement.baseline_selected_points
                     )
                     for k, point in enumerate(measurement.x):
                         if mask[k]:  # If true, point is selected
@@ -379,18 +378,21 @@ def filter_baseline_interactively(
                                 splineplot.y = measurement.spline
                             if splineplot.name in [
                                 f"corrected_{points.trace_name}",
-                                f"filtered_{points.trace_name}"
+                                f"filtered_{points.trace_name}",
                             ]:
                                 splineplot.y = measurement.filtered_baseline
 
     # Add the subplots for each column
     rows = 9
     cols = 1
-    plot_titles = list(measurements.keys()) + ['All measurements']
-    fig = go.FigureWidget(make_subplots(
-        rows=rows, cols=cols,
-        subplot_titles=plot_titles,
-        vertical_spacing=0.02)
+    plot_titles = list(measurements.keys()) + ["All measurements"]
+    fig = go.FigureWidget(
+        make_subplots(
+            rows=rows,
+            cols=cols,
+            subplot_titles=plot_titles,
+            vertical_spacing=0.02,
+        )
     )
 
     for x, measurement in enumerate(measurements.items()):
@@ -402,10 +404,10 @@ def filter_baseline_interactively(
                 y=data.y,
                 name=name,
                 line=dict(color="#636EFA"),  # Blue
-                mode='lines+markers',
+                mode="lines+markers",
             ),
-            row=x+1,
-            col=1
+            row=x + 1,
+            col=1,
         )
 
         # Add generated spline to same plot
@@ -413,13 +415,13 @@ def filter_baseline_interactively(
             go.Scatter(
                 x=data.x,
                 y=data.spline,
-                line=dict(color='#FF6692'),  # Red
-                mode='lines',
+                line=dict(color="#FF6692"),  # Red
+                mode="lines",
                 name=f"spline_{name}",
-                hoverinfo='skip',  # Disable clicking/hovering on this line
+                hoverinfo="skip",  # Disable clicking/hovering on this line
             ),
-            row=x+1,
-            col=1
+            row=x + 1,
+            col=1,
         )
 
         # Add subtracted baseline
@@ -428,14 +430,14 @@ def filter_baseline_interactively(
                 x=data.x,
                 y=data.filtered_baseline,
                 # Make the line grey
-                line=dict(color='#2F4F4F'),
-                mode='lines',
+                line=dict(color="#2F4F4F"),
+                mode="lines",
                 name=f"corrected_{name}",
                 opacity=0.2,
-                hoverinfo='skip',  # Disable clicking/hovering on this line
+                hoverinfo="skip",  # Disable clicking/hovering on this line
             ),
-            row=x+1,
-            col=1
+            row=x + 1,
+            col=1,
         )
 
     # Finally add a plot with all measurements together
@@ -447,7 +449,7 @@ def filter_baseline_interactively(
                 name=f"filtered_{name}",
             ),
             row=9,
-            col=1
+            col=1,
         )
 
     for subfig in fig.data:
@@ -455,7 +457,7 @@ def filter_baseline_interactively(
         subfig.on_click(cb_update_baseline_filter_plot)
 
         # Change colours of selected points (only on the raw data)
-        if 'spline' not in subfig.name:
+        if "spline" not in subfig.name:
             # Define the colour and size of points on first load
             # Set the start and end points to be selected. It would be better
             # to do this in the loop above, or actuate the callback on load,
@@ -473,12 +475,13 @@ def filter_baseline_interactively(
             subfig.marker.size = marker_size_list
 
             # Change scatter marker border colour/width (to make it visible)
-            subfig.marker.line.color = 'DarkSlateGrey'
+            subfig.marker.line.color = "DarkSlateGrey"
             subfig.marker.line.width = 0
 
     # Format and show fig
     fig.update_layout(
-        height=2000, width=900,
+        height=2000,
+        width=900,
         margin=dict(l=1, r=1, t=25, b=1),
     )
 
@@ -488,12 +491,12 @@ def filter_baseline_interactively(
 def integrate_peaks_interactively(
     measurements: Dict[str, Measurement],
     samples: int,
-    integration_method: str = 'trapz',
+    integration_method: str = "trapz",
 ) -> go.Figure:
-    ''' Generates a subplot given the dictionary of measurements
+    """Generates a subplot given the dictionary of measurements
 
     Allows user to select start and end of peaks to integrate
-    '''
+    """
 
     # Insure the integration data arrays are empty before starting otherwise
     # the plots interaction logic will break with the old data
@@ -506,9 +509,8 @@ def integrate_peaks_interactively(
         # is actuated, it returns a list
 
         for i, subplot in enumerate(fig.data):
-            if (
-                i == points.trace_index
-                and len(points.point_inds)
+            if i == points.trace_index and len(
+                points.point_inds
             ):  # Make sure we're working on the plot with changes
                 point_color = list(subplot.marker.color)
                 point_size = list(subplot.marker.size)
@@ -520,9 +522,7 @@ def integrate_peaks_interactively(
                     clicked_point = points.xs[0]
 
                     # If a user clicks on the same point twice
-                    if (
-                        clicked_point in measurement.integral_selected_points
-                    ):
+                    if clicked_point in measurement.integral_selected_points:
                         point_color[j] = constants.DEFAULT_POINT_COLOUR
                         point_size[j] = constants.DEFAULT_POINT_SIZE
                         measurement.remove_integral_point(clicked_point)
@@ -530,7 +530,7 @@ def integrate_peaks_interactively(
                         len(measurement.integral_selected_points)
                         <= (samples * 2) - 1
                     ):
-                        point_color[j] = '#2F4F4F'
+                        point_color[j] = "#2F4F4F"
                         point_size[j] = 20
                         measurement.add_integral_point(clicked_point)
                         measurement._calculate_integrals(
@@ -547,12 +547,12 @@ def integrate_peaks_interactively(
                         val = np.where(subplot.x == point)[0]
                         if val and len(val) and not np.isnan(val):
                             peak_index = val.item()
-                            point_color[peak_index] = (
-                                constants.INTEGRAL_PEAK_COLOUR
-                            )
-                            point_size[peak_index] = (
-                                constants.INTEGRAL_PEAK_SIZE
-                            )
+                            point_color[
+                                peak_index
+                            ] = constants.INTEGRAL_PEAK_COLOUR
+                            point_size[
+                                peak_index
+                            ] = constants.INTEGRAL_PEAK_SIZE
 
                     with fig.batch_update():
                         # Update the color and size of un/clicked point
@@ -562,11 +562,14 @@ def integrate_peaks_interactively(
     # Add the subplots for each column
     rows = 8
     cols = 1
-    plot_titles = list(measurements.keys()) + ['All measurements']
-    fig = go.FigureWidget(make_subplots(
-        rows=rows, cols=cols,
-        subplot_titles=plot_titles,
-        vertical_spacing=0.02)
+    plot_titles = list(measurements.keys()) + ["All measurements"]
+    fig = go.FigureWidget(
+        make_subplots(
+            rows=rows,
+            cols=cols,
+            subplot_titles=plot_titles,
+            vertical_spacing=0.02,
+        )
     )
 
     for x, measurement in enumerate(measurements.items()):
@@ -577,34 +580,35 @@ def integrate_peaks_interactively(
                 x=data.x,
                 y=data.filtered_baseline,
                 name=name,
-                mode='lines+markers',
+                mode="lines+markers",
             ),
-            row=x+1,
-            col=1
+            row=x + 1,
+            col=1,
         )
 
     DEFAULT_POINT_SIZE = 0
-    DEFAULT_POINT_COLOUR = '#a3a7e4'
+    DEFAULT_POINT_COLOUR = "#a3a7e4"
 
     for subfig in fig.data:
         # Callback for on click
         subfig.on_click(cb_update_integral_filter_plot)
 
         # Change colours of selected points (only on the raw data)
-        if 'spline' not in subfig.name:
+        if "spline" not in subfig.name:
             # Define the colour and size of points on first load
             subfig.marker.color = [DEFAULT_POINT_COLOUR] * len(subfig.y)
             subfig.marker.size = [DEFAULT_POINT_SIZE] * len(subfig.y)
 
             # Change scatter marker border colour/width (to make it visible)
-            subfig.marker.line.color = 'DarkSlateGrey'
+            subfig.marker.line.color = "DarkSlateGrey"
             subfig.marker.line.width = 0
 
     # Format and show fig
     fig.update_layout(
-        height=2000, width=900,
+        height=2000,
+        width=900,
         margin=dict(l=1, r=1, t=25, b=1),
-        )
+    )
 
     return fig
 
@@ -616,8 +620,10 @@ def output_data(
 ) -> None:
     # Create output dir based on UTC time, with absolute path
     if output_dir is None:
+        current_time = datetime.datetime.utcnow().isoformat().replace(":", "-")
         output_dir = os.path.join(
-            os.getcwd(), f'output-{datetime.datetime.utcnow()}'
+            os.getcwd(),
+            f"output-{current_time}",
         )
     else:
         # Add absolute path to output dir
@@ -644,7 +650,7 @@ def output_data(
 
     # Save baseline filtered data
     df = pd.DataFrame.from_dict(baseline_data)
-    df.set_index('Time/s', inplace=True, drop=True)
+    df.set_index("Time/s", inplace=True, drop=True)
     baseline_filename = os.path.join(
         output_dir, constants.FILENAME_BASELINE_SUBTRACTED_DATA
     )
@@ -653,14 +659,12 @@ def output_data(
 
     # Do the same for the raw data
     df = pd.DataFrame.from_dict(baseline_data)
-    df.set_index('Time/s', inplace=True, drop=True)
-    rawdata_filename = os.path.join(
-        output_dir, constants.FILENAME_RAW_DATA
-    )
+    df.set_index("Time/s", inplace=True, drop=True)
+    rawdata_filename = os.path.join(output_dir, constants.FILENAME_RAW_DATA)
     df.to_csv(rawdata_filename)
     print(f"Saved raw data to {rawdata_filename}")
 
-    header = ['measurement']
+    header = ["measurement"]
     for i in range(sample_count):
         for name in ["start", "end", "area", "peak_time", "peak_value"]:
             header.append(f"sample{i+1}_{name}")
@@ -669,24 +673,28 @@ def output_data(
     summary_filename = os.path.join(
         output_dir, constants.FILENAME_SUMMARY_DATA
     )
-    with open(summary_filename, 'w') as csvfile:
-        outputwriter = csv.writer(csvfile, delimiter=',')
+    with open(summary_filename, "w") as csvfile:
+        outputwriter = csv.writer(csvfile, delimiter=",")
         outputwriter.writerow(header)
         for name, measurement in measurements.items():
             row = []
             row.append(name)
             for i, sample in enumerate(measurement._integration_properties):
-                row += [sample['start'], sample['end'], sample['area'],
-                        sample['peak_x'], sample['peak_y']]
+                row += [
+                    sample["start"],
+                    sample["end"],
+                    sample["area"],
+                    sample["peak_x"],
+                    sample["peak_y"],
+                ]
             outputwriter.writerow(row)
     print(f"Saved summary data to {summary_filename}")
 
 
 def find_header_start(
-    filename_path: str,
-    header_text: str = constants.FILE_HEADER
+    filename_path: str, header_text: str = constants.FILE_HEADER
 ) -> int:
-    ''' Find the start of the header in the file
+    """Find the start of the header in the file
 
     Iterates through the file until it finds the header start. The header is
     defined as a constant in the constants module.
@@ -702,26 +710,25 @@ def find_header_start(
     -------
     int
         The line number of the header start
-    '''
+    """
 
     qty_empty_rows = 0
 
-    with open(filename_path, 'r') as f:
+    with open(filename_path, "r") as f:
         for i, line in enumerate(f):
             if line.strip() == header_text:
                 return i - qty_empty_rows
             elif len(line.strip()) == 0:
-                ''' Pandas does not count empty rows as part of the header '''
+                """Pandas does not count empty rows as part of the header"""
                 qty_empty_rows += 1
 
-    raise ValueError('Could not find header start')
+    raise ValueError("Could not find header start")
 
 
 def import_data(
-    filename_path: str,
-    header_start: int | None = None
+    filename_path: str, header_start: int | None = None
 ) -> Dict[str, Measurement]:
-    ''' Import data from a file
+    """Import data from a file
 
     The header start variable is given to pandas, which is the value of the
     line number of the header start. If this is not given, the function will
@@ -743,7 +750,7 @@ def import_data(
     -------
     Dict[str, Measurement]
         A dictionary of measurements
-    '''
+    """
 
     # Find the header start
     if header_start is None:
@@ -751,7 +758,7 @@ def import_data(
 
     # Import data
     df = pd.read_csv(filename_path, header=header_start)
-    df.set_index('Time/s', inplace=True)  # Set index to the time column
+    df.set_index("Time/s", inplace=True)  # Set index to the time column
     df.columns = df.columns.str.strip()  # Strip whitespace from the columns
 
     # Create a structure to hold all of the measurements (i1/A, i2/A, ...)


### PR DESCRIPTION
The output filename contained colons in it due to the timestamp which presented errors on Windows. These are now replaced with dashes.

The peak finding in the plots has been disabled as it was affecting the selection of regions where there was no peak. As it is not the most robust method of finding them, it will also be necessary to revisit the implementation should they be required in the data.